### PR TITLE
Formatting fixes for Typed PID Maker, FAIR DO Lab, ro-crate-java

### DIFF
--- a/_fair-do-lab/index.markdown
+++ b/_fair-do-lab/index.markdown
@@ -29,13 +29,9 @@ The FAIR DO Lab is based on its predecessor, the FAIR DO Testbed, which was [int
 
 Currently, the {{ page.title }} contains services which are not production-ready. While the development can be followed on GitHub, here are the most important points which are planned in near future:
 
-* The [Typed PID Maker] must reach version 1.0.
+* **The [Typed PID Maker] must reach version 1.0.** – Ideally, all services should be production-ready, but as the [Typed PID Maker] is a vital part of the {{ page.title }}, we consider its stability as a requirement for production use. As the {{ page.title }} is a living proposal, we do not have this requirement for all the services, but we offer [explicit documentation about the status of the different components](status.html).
 
-  Ideally, all services should be production-ready, but as the [Typed PID Maker] is a vital part of the {{ page.title }}, we consider its stability as a requirement for production use. As the {{ page.title }} is a living proposal, we do not have this requirement for all the services, but we offer [explicit documentation about the status of the different components](status.html).
-
-* Stable and flexible indexing process.
-
-  Searching for FAIR DOs is an important use case. We consider the current indexing process to be a proof-of-concept. For a 1.0 release, we plan to make it more flexible and use it to extract even more information about FAIR DOs.
+* **Stable and flexible indexing process.** – Searching for FAIR DOs is an important use case. We consider the current indexing process to be a proof-of-concept. For a 1.0 release, we plan to make it more flexible and use it to extract even more information about FAIR DOs.
 
 
 {% assign servicePosts = site.posts | where_exp: "post", "post.tags contains page.tag-name" %}

--- a/_ro-crate-java/index.markdown
+++ b/_ro-crate-java/index.markdown
@@ -32,9 +32,7 @@ In the context of development, we created benchmarks to compare the existing imp
 
 Ro-crate-java has been extensively tested using unit and integration tests and was successfully used in tests with existing crates, as well as examples from the specification. Yet, it is currently not being integrated in other software and has not experienced large amounts of use in practice, which is why we consider it beta software. We encourage you to try it for your project, to change this situation. Of course, we have a certain roadmap to do so ourself.
 
-- Apply the library in our own repositories and tools.
-
-  We are planning to integrate it with our software and use it in real projects.
+- **Apply the library in our own repositories and tools** – We are planning to integrate ro-crate-java with our software and use it in research projects.
 
 
 {% assign servicePosts = site.posts | where_exp: "post", "post.tags contains page.tag-name" %}

--- a/_ro-crate-java/index.markdown
+++ b/_ro-crate-java/index.markdown
@@ -15,7 +15,7 @@ tag-name: ro-crate-java
 
 Software libraries enable developers and users to create and modify such crates. They have the potential to enable valid crates without knowing the specification perfectly, and can be used to build this functionality into other applications.
 
-`ro-crate-java` is such a software library, written in the Java programming language. It has similar functionality as the existing implementations (`ro-crate-py`, `ro-crate-ruby`), which are implemented by the RO-Crate project. In contrast to those implementations, `ro-crate-java` has a strong focus on the correctness of the crates according to the specification, as well as performance. This means that `ro-crate-java` is especially well suited to create large crates, or large amounts of them. It can therefore, for example, be used to create crates for data in large repositories which are not packaged yet.
+Ro-crate-java is such a software library, written in the Java programming language. It has similar functionality as the existing implementations (ro-crate-py, ro-crate-ruby), which are implemented by the RO-Crate project. In contrast to those implementations, ro-crate-java has a strong focus on the correctness of the crates according to the specification, as well as performance. This means that ro-crate-java is especially well suited to create large crates, or large amounts of them. It can therefore, for example, be used to create crates for data in large repositories which are not packaged yet.
 
 In the context of development, we created benchmarks to compare the existing implementations. This allows developers of all implementations to find its weaknesses and strengths, but on the other hand also enables users to decide which implementation to use.
 
@@ -30,7 +30,7 @@ In the context of development, we created benchmarks to compare the existing imp
 
 ## Roadmap
 
-`ro-crate-java` has been extensively tested using unit and integration tests and was successfully used in tests with existing crates, as well as examples from the specification. Yet, it is currently not being integrated in other software and has not experienced large amounts of use in practice, which is why we consider it beta software. We encourage you to try it for your project, to change this situation. Of course, we have a certain roadmap to do so ourself.
+Ro-crate-java has been extensively tested using unit and integration tests and was successfully used in tests with existing crates, as well as examples from the specification. Yet, it is currently not being integrated in other software and has not experienced large amounts of use in practice, which is why we consider it beta software. We encourage you to try it for your project, to change this situation. Of course, we have a certain roadmap to do so ourself.
 
 - Apply the library in our own repositories and tools.
 

--- a/_typed-pid-maker/index.markdown
+++ b/_typed-pid-maker/index.markdown
@@ -44,17 +44,11 @@ The system follows the [RDA Recommendations on PID Information Types](https://rd
 
 Currently, the Typed PID Maker is in beta. While the development can be followed on GitHub, here are the most important points which have to be done before a 1.0 release:
 
-* Persist created PIDs locally.
+* **Persist created PIDs locally.** – Ensure recoverability of PIDs in case all other systems fail.
 
-  Ensure recoverability of PIDs in case all other systems fail.
+* **Persist sandboxed PID Systems in a local database.** – Enable more extensive tests. Currently, the sandboxed PIDs are stored in memory (RAM).
 
-* Persist sandboxed PID Systems in a local database.
-
-  Enable more extensive tests. Currently, the sandboxed PIDs are stored in memory (RAM).
-
-* Configurable Docker-Container for releases.
-
-  Make it easier to try the service locally and ease the work of administrators as well.
+* **Configurable Docker-Container for releases.** – Make it easier to try the service locally and ease the work of administrators as well.
 
 
 {% assign servicePosts = site.posts | where_exp: "post", "post.tags contains page.tag-name" %}


### PR DESCRIPTION
- ro-crate-java is not written in inline code spans anymore
- roadmaps are now formatted in a more readable way.