### PR TITLE
Make cards clickable but keep the cards text black, not blue.

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,12 +1,14 @@
 <div class="filterDiv w-full sm:w-1/2 md:w-1/3 flex-col p-3 {{ include.tags }}">
     <div class="bg-white rounded-lg shadow-lg overflow-hidden flex-1 flex flex-col h-full">
-        <a href="{{ include.target }}"><div class="bg-cover h-48" style="background-image: url({{ include.background }});"></div></a>
-        <div class="h-full p-4 flex-1 flex flex-col" style="">
-            <h3 class="mb-4 text-2xl">{{ include.title }}</h3>
-            <b class="mb-4 text-1xl">{{ include.subtitle }}</b>
-            <div class="mb-4 text-grey-darker text-sm flex-1">
-                <p>{{ include.content }}</p>
+        <a class="text-black" href="{{ include.target }}">
+            <div class="bg-cover h-48" style="background-image: url({{ include.background }});"></div>
+            <div class="h-full p-4 flex-1 flex flex-col" style="">
+                <h3 class="mb-4 text-2xl">{{ include.title }}</h3>
+                <b class="mb-4 text-1xl">{{ include.subtitle }}</b>
+                <div class="mb-4 text-grey-darker text-sm flex-1">
+                    <p>{{ include.content }}</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
 </div>

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,7 +1,7 @@
 <div class="filterDiv w-full sm:w-1/2 md:w-1/3 flex-col p-3 {{ include.tags }}">
-    <div class="bg-white rounded-lg shadow-lg overflow-hidden flex-1 flex flex-col h-full">
+    <div class="hover:shadow-2xl hover:border-blue-300 border-grey-50 border-2 bg-white rounded-lg shadow-lg overflow-hidden flex-1 flex flex-col h-full">
         <a href="{{ include.target }}" style="color: #2b2b2b;">
-            <div class="bg-cover h-48" style="background-image: url({{ include.background }});"></div>
+            <div class="bg-cover bg-white h-48" style="background-image: url({{ include.background }});"></div>
             <div class="h-full p-4 flex-1 flex flex-col" style="">
                 <h3 class="mb-4 text-2xl">{{ include.title }}</h3>
                 <b class="mb-4 text-1xl">{{ include.subtitle }}</b>

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -1,6 +1,6 @@
 <div class="filterDiv w-full sm:w-1/2 md:w-1/3 flex-col p-3 {{ include.tags }}">
     <div class="bg-white rounded-lg shadow-lg overflow-hidden flex-1 flex flex-col h-full">
-        <a class="text-black" href="{{ include.target }}">
+        <a href="{{ include.target }}" style="color: #2b2b2b;">
             <div class="bg-cover h-48" style="background-image: url({{ include.background }});"></div>
             <div class="h-full p-4 flex-1 flex flex-col" style="">
                 <h3 class="mb-4 text-2xl">{{ include.title }}</h3>


### PR DESCRIPTION
Moves the anchor tag a little out and adds a class to make sure the text is black. This might override some text colors, but for the current card's content, this is fine I guess. Fixes #10 

todo

- [x] text is currently black, but it was some darker grey before. The text-grey-darker instruction does not seem to work, though
- [x] we could use some hover effect to improve the user experience and hint that there is really something to click! like hover:underline class or so, maybe changing the text color.