### PR TITLE
Remove link to RDA WG on homepage

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -48,7 +48,7 @@ target="msc/index.html"
 background="assets/images/msc.png"
 title="Metadata Standards Catalog"
 subtitle="Looking for a standard?"
-content="The Metadata Standards Catalog is an information platform for finding and sharing metadata standards and tools. It is based on the outcome of the [Metadata Standards Catalog Working Group](https://www.rd-alliance.org/groups/metadata-standards-catalog-working-group.html).  
+content="The Metadata Standards Catalog is an information platform for finding and sharing metadata standards and tools. It is based on the outcome of the RDA Metadata Standards Catalog Working Group.
 "
 %}
 


### PR DESCRIPTION
Remove the link to the RDA Metadata Standards Catalog Working Group on the MSC card on the homepage.