### PR TITLE
Fix WAP server naming

### DIFF
--- a/_wap-server/index.markdown
+++ b/_wap-server/index.markdown
@@ -7,7 +7,7 @@ navigation_id: wap-server_index
 tag-name: wap-server
 ---
 
-# The Web Application Protocol Server
+# The Web Annotation Protocol Server
 
 This project provides a server for creating and managing annotations based on the [Web Annotation Data Model (WADM)](https://www.w3.org/TR/annotation-model/) 
 implementing the complete [Web Annotation Protocol (WAP)](https://www.w3.org/TR/annotation-protocol/). The service is realized as microservice using Spring Boot 


### PR DESCRIPTION
It is not and never was the _Web **Application** Protocol Server_

This long standing naming error must have spread over various information sources such as HMC documentation:

HMC
- in URL and text: https://helmholtz-metadaten.de/de/fair-data-commons/web-application-protocol-server
- text only: https://helmholtz-metadaten.de/de/werkzeuge/web-annotation-protocol-server

Matwerk
- Label and Graphic: https://nfdi-matwerk.de/solutions/software-solutions
- https://nfdi-matwerk.de/solutions/via-architecture/data-and-metadata-services

Other
- in a publication (WTF?) https://direct.mit.edu/dint/article/4/2/372/110664/Evaluation-of-Application-Possibilities-for
- some internal documentation (Software product list)

I am unsure about the origin of the error, could very well be this web page. I am even more unsure how to hunt down and fix the errors elsewhere, but it is not feasible to only fix it here for sure.
I only know that I neither can nor want to do anything about the outside information sources, so for lack of better ideas I am (randomly) paging @ThomasJejkal  and @Pfeil 
